### PR TITLE
Fix task count grammar

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -58,7 +58,13 @@ function renderTasks() {
 
 function updateTaskCount() {
     const activeTasks = tasks.filter(task => !task.completed).length;
-    taskCount.textContent = `${activeTasks} task${activeTasks !== 1 ? 's' : ''} left`;
+
+    // Ensure proper singular/plural grammar
+    if (activeTasks === 1) {
+        taskCount.textContent = '1 task left';
+    } else {
+        taskCount.textContent = `${activeTasks} tasks left`;
+    }
 }
 
 function addTask() {


### PR DESCRIPTION
## Summary
- adjust the `updateTaskCount` function to properly handle singular vs plural wording

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6843ed24fb388321ba15033a5ea9e354