### PR TITLE
Fix entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "todo-app",
   "version": "1.0.0",
   "description": "A simple to-do application to manage tasks",
-  "main": "index.js",
+  "main": "src/app.js",
   "scripts": {
     "start": "http-server src -p 8080",
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
## Summary
- fix package entrypoint so it points to `src/app.js`

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm start` *(fails: http-server not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843ef44222883219f83a6f93bce4562