### PR TITLE
Fix task text color for dark mode

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -141,12 +141,12 @@ h1 {
 .task-text {
     flex: 1;
     font-size: 16px;
-    color: #374151;
+    color: var(--color-text);
 }
 
 .completed .task-text {
     text-decoration: line-through;
-    color: #aaa;
+    color: var(--color-text-secondary);
 }
 
 .task-delete {


### PR DESCRIPTION
## Summary
- ensure task text uses theme colors so it's visible in dark mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684405a717508321b1ecf158af319261